### PR TITLE
Add Conjur suite certification levels

### DIFF
--- a/Conjur/README.md
+++ b/Conjur/README.md
@@ -1,11 +1,11 @@
 # CyberArk Conjur
-Welcome, and thank you for your interest in CyberArk Conjur! 
+Welcome, and thank you for your interest in CyberArk Conjur!
 
 Here, you'll find useful information from everything from our style-guides to our code of conduct.
 For a full list of projects, check out our [open source landing
 page](https://cyberark.github.io/conjur/).
 
-To learn more about our team, you'll find some [helpful links below](#learn-more).
+To learn more about our team and our products, you'll find some [helpful links below](#learn-more).
 
 ## Table of Contents
 
@@ -34,10 +34,18 @@ first issue, to learning best practices surrounding the languages we use.
     + [Bash](conventions/bash-style-guide.md)
 
 ## Learn More
-- **Website** ([conjur.org](conjur.org)) - Learn more about who we are and what we do, and get started
-   with our tutorials and documentation.
+- **Website** ([conjur.org](conjur.org)) - Visit our website to learn more about
+  getting started with Conjur, including tutorials and documentation.
 
 - **Blog** ([blog.conjur.org](blog.conjur.org)) - CyberArk's DevOps security blog.
+
+- **Certification Levels** - Our library of open source tools include community-contributed
+  projects, tools and integrations built for Conjur OSS, and products that have undergone
+  additional testing and validation to ensure they work well with [CyberArk Dynamic Access
+  Provider](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm).
+  Read up on our software [**Certification Levels**](./conventions/certification-levels.md)
+  for detailed information about the difference between **Community**, **Trusted**, and
+  **Certified** products.
 
 ## Questions?
  Reach out to us on [Discourse](https://discuss.cyberarkcommons.org), our official forum for

--- a/Conjur/conventions/certification-levels.md
+++ b/Conjur/conventions/certification-levels.md
@@ -1,0 +1,131 @@
+# Conjur Suite Certification Levels
+
+This document provides detailed information about certification levels of components
+that are part of the CyberArk Conjur [Open Source Suite](https://cyberark.github.io/conjur/)
+of tools.
+
+CyberArk maintains three levels of certification to indicate how far a particular
+component has been reviewed and tested by CyberArk:
+- **Community**: Briefly. We want to help you contribute and get out of the way.
+- **Trusted**: CyberArk has reviewed and tested this component and trusts it to be
+  used with Conjur OSS.
+- **Certified**: CyberArk has reviewed, tested, and approved this component to be
+  used with the _[CyberArk Dynamic Access Provider](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm)_
+  (DAP) product. Note that DAP itself is built directly from Conjur certified core components.
+
+## Certification Levels at a Glance
+
+|  Level       	| Description                                                            	| Documentation 	| Completeness                                          | Tests                                                                                                         | Security                                                                                  | Support                                     	|
+|:-------------:|-------------------------------------------------------------------------|-----------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------------------------|
+| **Community** | Community contributions: Easy to add value                              | Basic         	| Feature can be demonstrated with a single use case    | Not required                                                                                                  | Not reviewed                                                                             	| Community                                   	|
+| **Trusted**   | Tested and trusted to work with **Conjur OSS**                         	| Full          	| Feature implementation is largely complete            | Comprehensive tests <br><br>No known `Critical` or `High` severity bugs | Automated security scans<br><br>Follows security best practices       | Community support with CyberArk assistance  	|
+| **Certified** | Officially approved for use with **DAP**           	| Comprehensive 	| Feature implementation is complete when used with **DAP** | Comprehensive tests <br><br>No known `Critical` or `High` severity bugs<br><br>load-tested at expected Enterprise production loads | Automated security scans<br><br>Security level complies with **DAP** requirements             | Fully supported by CyberArk for use in **DAP**  	|
+
+---
+
+
+## Community
+
+### Description
+Community features or projects are **contributed by the community** and **are not
+reviewed or supported by CyberArk Engineering**. In particular, Community features
+or projects **have not had a CyberArk security review**.
+
+For the purposes of this certification level, community members may include:
+- CyberArk Conjur Engineering team members
+- Other CyberArk employees including BizDev, Extensions team, Pre-sales,  Professional / Security Services
+- Non-CyberArk contributors: Partners, End Users, DevSecOps Engineers, etc
+
+### Characteristics
+Characteristics of a Community Level feature:
+
+- Feature/Product has a name.
+- Feature can be demonstrated with a single use case.
+- Feature has value to our customers.
+- Feature is available in a tagged version.
+  - For CyberArk-maintained software, GitHub tags will be used. If the feature
+    is part of a larger project, it must be feature-flagged off by default.
+  - For non-CyberArk maintained software, versioned release artifacts will be
+    uploaded to CyberArk Marketplace with the "Community" Certification Level.
+    A [software license](https://opensource.org/licenses) should be specified.
+- Basic documentation (e.g. a README.md file) has been written for the feature, and includes:
+  - A clear indication of its **Community** Certification Level.
+  - Description of covered use case.
+  - Supported versions of relevant components (eg tools that it integrates with,
+    etc).
+  - Known limitations.
+
+## Trusted
+
+### Description
+A feature or project with a **Trusted** Certification Level has been reviewed by
+CyberArk Engineering to verify that it will securely work with Conjur OSS as documented.
+
+### Characteristics
+Taking a feature from the Community certification level to the Trusted level involves
+a development, documentation, and testing effort to meet the following criteria:
+
+- Feature implementation is largely complete
+  - Majority of edge cases for the key feature use case have been implemented.
+  - No known bugs of `Critical` or `High` severity exist. (TBA - link to rubric for defining bug severity)
+- Feature is available in a tagged version:
+  - For CyberArk-maintained software, GitHub tags will be used.
+  - For non-CyberArk maintained software, versioned release artifacts will be
+    uploaded to CyberArk Marketplace with the "Trusted" Certification Level.
+- Feature has been fully documented and includes:
+  - Supported versions of relevant components (eg tools that it integrates with,
+    etc).
+  - Known limitations.
+  - Basic troubleshooting information.
+  - API documentation updates (if relevant, e.g. for updates to the Conjur API).
+- Feature has comprehensive tests
+  - Automated unit and integration test suite has been implemented for use case.
+    - All main positive tests exist.
+    - Many negative tests exist.
+    - Might be some edge cases remaining to test, but the covered edge cases
+      should be tested.
+- Feature passed a basic security review and follows security best practices
+  (e.g. STRIDE, OWASP Top 10, GDPR).
+
+In addition, if the feature is maintained by CyberArk, the following conditions must be met:
+  - Documentation is published on appropriate CyberArk documentation site(s)
+  - Feature is clearly labeled as **Trusted** Certification Level.
+  - Feature has automated vulnerability scanning integrated into its pipeline
+    which runs with no Critical or High vulnerabilities.
+  - Project has an up-to-date acknowledgements file and all dependencies use
+    approved licenses (MIT, Apache 2.0, BSD) or have been individually approved.
+
+New versions of "Trusted" features will be re-reviewed to verify they continue
+to meet the "Trusted" criteria before they may continue to be included in a new
+version at the "Trusted" level.
+
+
+## Certified
+
+### Description
+A "Trusted" feature or project may be **Certified** to work with CyberArk DAP.
+Features that are "Certified" have been reviewed by CyberArk Engineering to verify
+that they will securely work with CyberArk DAP as documented. In addition, CyberArk
+offers Enterprise-level support for these features.
+
+### Characteristics
+In order for a "Trusted" feature to become "Certified" for CyberArk DAP, the
+following **additional** criteria must be met:
+- Feature implementation is complete when used with CyberArk DAP.
+  - All identified edge cases have been implemented.
+  - No known bugs of `Critical` or `High` severity exist.
+- Feature includes automated tests to validate functional workflows with CyberArk DAP.
+  - Feature has been load-tested at expected Enterprise production loads.
+  - Performance goals for feature working with CyberArk DAP have been met and
+    confirmed by testing/usage data.
+  - Code coverage meets targets for Enterprise-level products.
+- Feature documentation is complete.
+  - Documentation for using the feature with CyberArk DAP exists on the appropriate
+    documentation site(s), and includes:
+    - Supported versions of relevant components (eg tools that it integrates with,
+      etc).
+    - Known limitations.
+    - Comprehensive troubleshooting information.
+    - Updated API documentation (if relevant, e.g. for updates to the Conjur API).
+- Feature passed a comprehensive security review, ensuring it complies with the
+  CyberArk DAP security requirements.


### PR DESCRIPTION
Add the certification levels doc to the Conjur/conventions folder, and add a
link that references it and provides some context to the Conjur/README