### PR TITLE
Fix gitleaks pre-commit script to support SourceTree

### DIFF
--- a/Conjur/conventions/git-tips-and-tricks.md
+++ b/Conjur/conventions/git-tips-and-tricks.md
@@ -192,6 +192,9 @@ and have git check for secrets before every push.
        #!/bin/bash -eu
 
        set -o pipefail
+       
+       # Need this to allow SourceTree to commit. See: https://stackoverflow.com/a/51415687
+       export PATH=/usr/local/bin:$PATH
 
        if ! command -v gitleaks &> /dev/null; then
          echo "ERROR: Gitleaks not installed!"


### PR DESCRIPTION
Currently, the gitleaks pre-commit script is blocking all commits when using SourceTree.
To fix it, it needs to include `export PATH=/usr/local/bin:$PATH` at the beginning, as answered here:
https://stackoverflow.com/a/51415687