### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/Conjur/README.md
+++ b/Conjur/README.md
@@ -45,7 +45,7 @@ first issue, to learning best practices surrounding the languages we use.
 - **Blog** ([blog.conjur.org](blog.conjur.org)) - CyberArk's DevOps security blog.
 
 - **Certification Levels** - Our library of open source tools include community-contributed
-  projects, tools and integrations built for Conjur OSS, and products that have undergone
+  projects, tools and integrations built for Conjur Open Source, and products that have undergone
   additional testing and validation to ensure they work well with [CyberArk Dynamic Access
   Provider](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm).
   Read up on our software [**Certification Levels**](./conventions/certification-levels.md)

--- a/Conjur/conventions/certification-levels.md
+++ b/Conjur/conventions/certification-levels.md
@@ -8,18 +8,18 @@ CyberArk maintains three levels of certification to indicate how far a particula
 component has been reviewed and tested by CyberArk:
 - **Community**: Briefly. We want to help you contribute and get out of the way.
 - **Trusted**: CyberArk has reviewed and tested this component and trusts it to be
-  used with Conjur OSS.
+  used with Conjur Open Source.
 - **Certified**: CyberArk has reviewed, tested, and approved this component to be
-  used with the _[CyberArk Dynamic Access Provider](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm)_
-  (DAP) product. Note that DAP itself is built directly from Conjur certified core components.
+  used with the _[CyberArk Conjur Enterprise](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/Latest/en/Content/Resources/_TopNav/cc_Home.htm)_
+  (formerly DAP) product. Note that Conjur Enterprise itself is built directly from Conjur certified core components.
 
 ## Certification Levels at a Glance
 
 |  Level       	| Description                                                            	| Documentation 	| Completeness                                          | Tests                                                                                                         | Security                                                                                  | Support                                     	|
 |:-------------:|-------------------------------------------------------------------------|-----------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------------------------|
 | **Community** | Community contributions: Easy to add value                              | Basic         	| Feature can be demonstrated with a single use case    | Not required                                                                                                  | Not reviewed                                                                             	| Community                                   	|
-| **Trusted**   | Tested and trusted to work with **Conjur OSS**                         	| Full          	| Feature implementation is largely complete            | Comprehensive tests <br><br>No known `Critical` or `High` severity bugs | Automated security scans<br><br>Follows security best practices       | Community support with CyberArk assistance  	|
-| **Certified** | Officially approved for use with **DAP**           	| Comprehensive 	| Feature implementation is complete when used with **DAP** | Comprehensive tests <br><br>No known `Critical` or `High` severity bugs<br><br>load-tested at expected Enterprise production loads | Automated security scans<br><br>Security level complies with **DAP** requirements             | Fully supported by CyberArk for use in **DAP**  	|
+| **Trusted**   | Tested and trusted to work with **Conjur Open Source**                         	| Full          	| Feature implementation is largely complete            | Comprehensive tests <br><br>No known `Critical` or `High` severity bugs | Automated security scans<br><br>Follows security best practices       | Community support with CyberArk assistance  	|
+| **Certified** | Officially approved for use with **Conjur Enterprise**           	| Comprehensive 	| Feature implementation is complete when used with **Conjur Enterprise** | Comprehensive tests <br><br>No known `Critical` or `High` severity bugs<br><br>load-tested at expected Enterprise production loads | Automated security scans<br><br>Security level complies with **Conjur Enterprise** requirements             | Fully supported by CyberArk for use in **Conjur Enterprise**  	|
 
 ---
 
@@ -59,7 +59,7 @@ Characteristics of a Community Level feature:
 
 ### Description
 A feature or project with a **Trusted** Certification Level has been reviewed by
-CyberArk Engineering to verify that it will securely work with Conjur OSS as documented.
+CyberArk Engineering to verify that it will securely work with Conjur Open Source as documented.
 
 ### Characteristics
 Taking a feature from the Community certification level to the Trusted level involves
@@ -103,24 +103,24 @@ version at the "Trusted" level.
 ## Certified
 
 ### Description
-A "Trusted" feature or project may be **Certified** to work with CyberArk DAP.
+A "Trusted" feature or project may be **Certified** to work with CyberArk Conjur Enterprise.
 Features that are "Certified" have been reviewed by CyberArk Engineering to verify
-that they will securely work with CyberArk DAP as documented. In addition, CyberArk
+that they will securely work with CyberArk Conjur Enterprise as documented. In addition, CyberArk
 offers Enterprise-level support for these features.
 
 ### Characteristics
-In order for a "Trusted" feature to become "Certified" for CyberArk DAP, the
+In order for a "Trusted" feature to become "Certified" for CyberArk Conjur Enterprise, the
 following **additional** criteria must be met:
-- Feature implementation is complete when used with CyberArk DAP.
+- Feature implementation is complete when used with CyberArk Conjur Enterprise.
   - All identified edge cases have been implemented.
   - No known bugs of `Critical` or `High` severity exist.
-- Feature includes automated tests to validate functional workflows with CyberArk DAP.
+- Feature includes automated tests to validate functional workflows with CyberArk Conjur Enterprise.
   - Feature has been load-tested at expected Enterprise production loads.
-  - Performance goals for feature working with CyberArk DAP have been met and
+  - Performance goals for feature working with CyberArk Conjur Enterprise have been met and
     confirmed by testing/usage data.
   - Code coverage meets targets for Enterprise-level products.
 - Feature documentation is complete.
-  - Documentation for using the feature with CyberArk DAP exists on the appropriate
+  - Documentation for using the feature with CyberArk Conjur Enterprise exists on the appropriate
     documentation site(s), and includes:
     - Supported versions of relevant components (eg tools that it integrates with,
       etc).
@@ -128,4 +128,4 @@ following **additional** criteria must be met:
     - Comprehensive troubleshooting information.
     - Updated API documentation (if relevant, e.g. for updates to the Conjur API).
 - Feature passed a comprehensive security review, ensuring it complies with the
-  CyberArk DAP security requirements.
+  CyberArk Conjur Enterprise security requirements.


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
